### PR TITLE
feat: Add title attribute to dayPropGetter to enable tooltips in monthly view

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -47,12 +47,13 @@ class BackgroundCells extends React.Component {
       <div className="rbc-row-bg" ref={this.containerRef}>
         {range.map((date, index) => {
           let selected = selecting && index >= startIdx && index <= endIdx
-          const { className, style } = getters.dayProp(date)
+          const { className, style, title } = getters.dayProp(date)
 
           return (
             <Wrapper key={index} value={date} range={range}>
               <div
                 style={style}
+                title={title}
                 className={clsx(
                   'rbc-day-bg',
                   className,


### PR DESCRIPTION
**Alternative fix (or nice to have addition) for issue**: https://github.com/jquense/react-big-calendar/issues/2446

This PR tries to enable tooltips using `dayPropGetter` on monthly calendar view. As explained here in the issue there is a need for background events in the monthly view bit until that gets resolved this could be a nice to have. This allows you to add tooltip to any day slot in monthly view which I think it is quite useful if you want to add better explanation why some styling like bg-color has changed and something similar.
